### PR TITLE
Deduplicator

### DIFF
--- a/implementation/include/Callbacks/MacroNameCollector.hh
+++ b/implementation/include/Callbacks/MacroNameCollector.hh
@@ -18,12 +18,14 @@ namespace Callbacks
     private:
         std::set<std::string> &MacroNames;
         std::set<std::string> &MultiplyDefinedMacros;
+        bool Verbose;
         clang::SourceManager &SM;
         const clang::LangOptions &LO;
 
     public:
         MacroNameCollector(std::set<std::string> &MacroNames,
                            std::set<std::string> &MultiplyDefinedMacros,
+                           bool Verbose,
                            clang::SourceManager &SM,
                            const clang::LangOptions &LO);
 

--- a/implementation/include/Cpp2C/Cpp2CAction.hh
+++ b/implementation/include/Cpp2C/Cpp2CAction.hh
@@ -2,6 +2,7 @@
 
 #include "Cpp2C/Cpp2CCommand.hh"
 #include "Transformer/TransformerSettings.hh"
+#include "Deduplicator/DeduplicatorSettings.hh"
 #include "AnnotationRemover/AnnotationRemoverSettings.hh"
 
 #include "clang/Frontend/CompilerInstance.h"
@@ -33,6 +34,7 @@ namespace Cpp2C
     private:
         Cpp2CCommand Command = HELP;
         Transformer::TransformerSettings TSettings;
+        Deduplicator::DeduplicatorSettings DDSettings;
         AnnotationRemover::AnnotationRemoverSettings ARSettings;
     };
 

--- a/implementation/include/Cpp2C/Cpp2CCommand.hh
+++ b/implementation/include/Cpp2C/Cpp2CCommand.hh
@@ -6,6 +6,7 @@ namespace Cpp2C
     {
         HELP,
         TRANSFORM,
+        DEDUPLICATE,
         REMOVE_ANNOTATIONS
     };
 } // namespace Cpp2C

--- a/implementation/include/CppSig/MacroForest.hh
+++ b/implementation/include/CppSig/MacroForest.hh
@@ -35,6 +35,9 @@ namespace CppSig
         // The Clang CompilerInstance
         clang::CompilerInstance &CI;
 
+        // Whether to emit debug messages to stderr
+        bool Verbose;
+
         // The roots of all macro expansions in a program
         Roots &MacroRoots;
 
@@ -57,7 +60,10 @@ namespace CppSig
     public:
         // Copy constructor
         // Gets the Ctx from CI
-        MacroForest(clang::CompilerInstance &CI, Roots &roots);
+        MacroForest(
+            clang::CompilerInstance &CI,
+            bool Verbose,
+            Roots &roots);
 
         // Callback called when the preprocessor encounters a macro expansion.
         // Adds the expansion to the MacroForest

--- a/implementation/include/Deduplicator/DeduplicatorConsumer.hh
+++ b/implementation/include/Deduplicator/DeduplicatorConsumer.hh
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Deduplicator/DeduplicatorSettings.hh"
+
+#include "clang/AST/ASTConsumer.h"
+
+namespace Deduplicator
+{
+    // AST consumer that removes duplicate
+    // transformed declarations and definitions
+    class DeduplicatorConsumer : public clang::ASTConsumer
+    {
+
+    private:
+        DeduplicatorSettings DDSettings;
+
+    public:
+        explicit DeduplicatorConsumer(DeduplicatorSettings DDSettings);
+
+        virtual void HandleTranslationUnit(clang::ASTContext &Ctx);
+    };
+} // namespace Deduplicator

--- a/implementation/include/Deduplicator/DeduplicatorSettings.hh
+++ b/implementation/include/Deduplicator/DeduplicatorSettings.hh
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace Deduplicator
+{
+    struct DeduplicatorSettings
+    {
+        bool OverwriteFiles = false;
+    };
+} // namespace Deduplicator

--- a/implementation/include/Utils/ExpansionUtils.hh
+++ b/implementation/include/Utils/ExpansionUtils.hh
@@ -3,6 +3,8 @@
 #include "CppSig/MacroExpansionNode.hh"
 #include "SourceRangeCollection.hh"
 
+#include "nlohmann/single_include/json.hpp"
+
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Lex/MacroInfo.h"
@@ -11,10 +13,10 @@
 #include <string>
 #include <vector>
 
+// TODO: Divide these functions up under more meaningful namespaces
+
 namespace Utils
 {
-    using CppSig::MacroExpansionNode;
-
     // Returns true if the given expansion transforms to a variable, false
     // otherwise
     //
@@ -46,7 +48,7 @@ namespace Utils
     // function signature; false otherwise
     bool expansionHasUnambiguousSignature(
         clang::ASTContext &Ctx,
-        MacroExpansionNode *Expansion);
+        CppSig::MacroExpansionNode *Expansion);
 
     // Returns true if the given variable declaration is a global variable,
     // false otherwise
@@ -139,5 +141,14 @@ namespace Utils
     // Given a pointer to a Type object, removes all pointers in the type
     // and returns the base type
     clang::QualType getPointeeType(clang::QualType T);
+
+    // Given a pointer to a Decl, returns the string representation of
+    // the Decl's first 'annotate' attribute, or the empty string
+    // if it doesn't have one
+    std::string getFirstAnnotationOrEmpty(clang::Decl *);
+
+    // Given an entire annotation string, extracts the braced portion of the
+    // string, parses it to JSON, and the returns the parsed value
+    nlohmann::json annotationStringToJson(std::string anno);
 
 } // namespace Utils

--- a/implementation/include/Utils/ExpansionUtils.hh
+++ b/implementation/include/Utils/ExpansionUtils.hh
@@ -8,6 +8,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/LangOptions.h"
 #include "clang/Lex/MacroInfo.h"
+#include "clang/Rewrite/Core/Rewriter.h"
 
 #include <set>
 #include <string>
@@ -141,14 +142,5 @@ namespace Utils
     // Given a pointer to a Type object, removes all pointers in the type
     // and returns the base type
     clang::QualType getPointeeType(clang::QualType T);
-
-    // Given a pointer to a Decl, returns the string representation of
-    // the Decl's first 'annotate' attribute, or the empty string
-    // if it doesn't have one
-    std::string getFirstAnnotationOrEmpty(clang::Decl *);
-
-    // Given an entire annotation string, extracts the braced portion of the
-    // string, parses it to JSON, and the returns the parsed value
-    nlohmann::json annotationStringToJson(std::string anno);
 
 } // namespace Utils

--- a/implementation/include/Utils/TransformedDeclarationAnnotation.hh
+++ b/implementation/include/Utils/TransformedDeclarationAnnotation.hh
@@ -1,6 +1,12 @@
 #pragma once
 
 #include "nlohmann/single_include/json.hpp"
+
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Attr.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+
 #include <string>
 #include <stddef.h>
 
@@ -49,5 +55,14 @@ namespace Utils
 
     // Hashes a given TransformedDeclarationAnnotation instance to a string
     std::string hashTDA(const TransformedDeclarationAnnotation &TDA);
+
+    // Given a pointer to a Decl, returns the string representation of
+    // the Decl's first 'annotate' attribute, or the empty string
+    // if it doesn't have one
+    std::string getFirstAnnotationOrEmpty(clang::Decl *);
+
+    // Given an entire annotation string, extracts the braced portion of the
+    // string, parses it to JSON, and the returns the parsed value
+    nlohmann::json annotationStringToJson(std::string anno);
 
 } // namespace Utils

--- a/implementation/include/Utils/TransformedDeclarationAnnotation.hh
+++ b/implementation/include/Utils/TransformedDeclarationAnnotation.hh
@@ -42,4 +42,12 @@ namespace Utils
     // This enables us to wrap the emitted JSON string in another string
     // https://stackoverflow.com/questions/7724448/simple-json-string-escape-for-c
     std::string escape_json(const std::string &s);
+
+    // Hashes the original macro that a TransformedDeclarationAnnotation was
+    // transformed from to a string
+    std::string hashTDAOriginalMacro(const TransformedDeclarationAnnotation &TDA);
+
+    // Hashes a given TransformedDeclarationAnnotation instance to a string
+    std::string hashTDA(const TransformedDeclarationAnnotation &TDA);
+
 } // namespace Utils

--- a/implementation/include/Visitors/DeclRefExprAndCallExprDDVisitor.hh
+++ b/implementation/include/Visitors/DeclRefExprAndCallExprDDVisitor.hh
@@ -14,12 +14,12 @@ namespace Visitors
     {
     private:
         clang::Rewriter &RW;
-        std::map<std::string, std::string> &TransformedDeclNameToCanonicalName;
+        std::map<clang::NamedDecl *, clang::NamedDecl *> &TransformedDeclToCanonicalDecl;
 
     public:
         explicit DeclRefExprAndCallExprDDVisitor(
             clang::Rewriter &RW,
-            std::map<std::string, std::string> &TransformedDeclNameToCanonicalName);
+            std::map<clang::NamedDecl *, clang::NamedDecl *> &TransformedDeclToCanonicalDecl);
 
         bool VisitExpr(clang::Expr *E);
     };

--- a/implementation/include/Visitors/DeclRefExprAndCallExprDDVisitor.hh
+++ b/implementation/include/Visitors/DeclRefExprAndCallExprDDVisitor.hh
@@ -1,0 +1,26 @@
+// DeclRefExprAndCallExprDDVisitor.hh
+// Replaces decl refs / calls to deduplicated decls with the name
+// of their transformed macro's canonical decl
+
+#pragma once
+
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+
+namespace Visitors
+{
+    class DeclRefExprAndCallExprDDVisitor
+        : public clang::RecursiveASTVisitor<DeclRefExprAndCallExprDDVisitor>
+    {
+    private:
+        clang::Rewriter &RW;
+        std::map<std::string, std::string> &TransformedDeclNameToCanonicalName;
+
+    public:
+        explicit DeclRefExprAndCallExprDDVisitor(
+            clang::Rewriter &RW,
+            std::map<std::string, std::string> &TransformedDeclNameToCanonicalName);
+
+        bool VisitExpr(clang::Expr *E);
+    };
+} // namespace Visitors

--- a/implementation/include/Visitors/ForwardDeclDDVisitor.hh
+++ b/implementation/include/Visitors/ForwardDeclDDVisitor.hh
@@ -1,0 +1,22 @@
+// ForwardDeclDDVisitor.hh
+// Deduplicates struct/union/enum forward decls emitted by Cpp2C
+
+#pragma once
+
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+
+namespace Visitors
+{
+    class ForwardDeclDDVisitor
+        : public clang::RecursiveASTVisitor<ForwardDeclDDVisitor>
+    {
+    private:
+        clang::Rewriter &RW;
+
+    public:
+        explicit ForwardDeclDDVisitor(clang::Rewriter &RW);
+
+        bool VisitTagDecl(clang::TagDecl *TD);
+    };
+} // namespace Visitors

--- a/implementation/include/Visitors/FunctionDefinitionDDVisitor.hh
+++ b/implementation/include/Visitors/FunctionDefinitionDDVisitor.hh
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "nlohmann/single_include/json.hpp"
+
 #include "clang/AST/RecursiveASTVisitor.h"
 #include "clang/Rewrite/Core/Rewriter.h"
 
@@ -16,14 +18,14 @@ namespace Visitors
     {
     private:
         clang::Rewriter &RW;
-        std::set<std::string> &TransformedDeclNames;
-        std::set<clang::Decl *> &CanonicalDecls;
+        std::map<clang::NamedDecl *, clang::NamedDecl *> &TransformedDeclToCanonicalDecl;
+        std::map<clang::NamedDecl *, nlohmann::json> &TransformedDeclToJSON;
 
     public:
         explicit FunctionDefinitionDDVisitor(
             clang::Rewriter &RW,
-            std::set<std::string> &TransformedDeclNames,
-            std::set<clang::Decl *> &CanonicalDecls);
+            std::map<clang::NamedDecl *, clang::NamedDecl *> &TransformedDeclToCanonicalDecl,
+            std::map<clang::NamedDecl *, nlohmann::json> &TransformedDeclToJSON);
 
         bool VisitNamedDecl(clang::NamedDecl *ND);
     };

--- a/implementation/include/Visitors/FunctionDefinitionDDVisitor.hh
+++ b/implementation/include/Visitors/FunctionDefinitionDDVisitor.hh
@@ -1,0 +1,30 @@
+// FunctionDefinitionDDVisitor.hh
+// Deduplicates transformed function definitions by removing each
+// transformed macro's "non-canonical" transformations
+
+#pragma once
+
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+
+#include <map>
+
+namespace Visitors
+{
+    class FunctionDefinitionDDVisitor
+        : public clang::RecursiveASTVisitor<FunctionDefinitionDDVisitor>
+    {
+    private:
+        clang::Rewriter &RW;
+        std::set<std::string> &TransformedDeclNames;
+        std::set<clang::Decl *> &CanonicalDecls;
+
+    public:
+        explicit FunctionDefinitionDDVisitor(
+            clang::Rewriter &RW,
+            std::set<std::string> &TransformedDeclNames,
+            std::set<clang::Decl *> &CanonicalDecls);
+
+        bool VisitNamedDecl(clang::NamedDecl *ND);
+    };
+} // namespace Visitors

--- a/implementation/include/Visitors/MacroTransformationMapperVisitor.hh
+++ b/implementation/include/Visitors/MacroTransformationMapperVisitor.hh
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "nlohmann/single_include/json.hpp"
+
 #include "clang/AST/RecursiveASTVisitor.h"
 
 #include <map>
@@ -16,13 +18,15 @@ namespace Visitors
         : public clang::RecursiveASTVisitor<MacroTransformationMapperVisitor>
     {
     private:
-        std::map<std::string, std::vector<clang::Decl *>> TransformedMacroMap;
-        std::map<clang::Decl *, std::string> TransformedDeclToMacroHash;
+        std::map<std::string, std::vector<clang::NamedDecl *>> MacroHashToTransformedDecls;
+        std::map<clang::NamedDecl *, std::string> TransformedDeclToMacroHash;
+        std::map<clang::NamedDecl *, nlohmann::json> TransformedDeclToJSONAnnotation;
 
     public:
-        bool VisitDecl(clang::Decl *D);
+        bool VisitNamedDecl(clang::NamedDecl *ND);
 
-        std::map<std::string, std::vector<clang::Decl *>> &getTransformedMacroMapRef();
-        std::map<clang::Decl *, std::string> &getTransformedDeclToMacroHashRef();
+        std::map<std::string, std::vector<clang::NamedDecl *>> &getMacroHashToTransformedDeclsRef();
+        std::map<clang::NamedDecl *, std::string> &getTransformedDeclToMacroHashRef();
+        std::map<clang::NamedDecl *, nlohmann::json> &getTransformedDeclToJSONAnnotationRef();
     };
 } // namespace Visitors

--- a/implementation/include/Visitors/MacroTransformationMapperVisitor.hh
+++ b/implementation/include/Visitors/MacroTransformationMapperVisitor.hh
@@ -1,0 +1,28 @@
+// MacroTransformationMapperVisitor.hh
+// Maps hashes of transformed macro definitions to a vector of the
+// declarations of the functions/variables they were transformed to,
+// and maps transformed decls to the hashes of the macros they were
+// transformed from
+
+#pragma once
+
+#include "clang/AST/RecursiveASTVisitor.h"
+
+#include <map>
+
+namespace Visitors
+{
+    class MacroTransformationMapperVisitor
+        : public clang::RecursiveASTVisitor<MacroTransformationMapperVisitor>
+    {
+    private:
+        std::map<std::string, std::vector<clang::Decl *>> TransformedMacroMap;
+        std::map<clang::Decl *, std::string> TransformedDeclToMacroHash;
+
+    public:
+        bool VisitDecl(clang::Decl *D);
+
+        std::map<std::string, std::vector<clang::Decl *>> &getTransformedMacroMapRef();
+        std::map<clang::Decl *, std::string> &getTransformedDeclToMacroHashRef();
+    };
+} // namespace Visitors

--- a/implementation/src/CMakeLists.txt
+++ b/implementation/src/CMakeLists.txt
@@ -34,6 +34,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O1")
 
 add_library(Cpp2C SHARED
   AnnotationRemover/AnnotationRemoverConsumer.cc
+  Deduplicator/DeduplicatorConsumer.cc
   Callbacks/ForestCollector.cc
   Callbacks/MacroNameCollector.cc
   Cpp2C.cc
@@ -53,8 +54,12 @@ add_library(Cpp2C SHARED
   Visitors/CollectCpp2CAnnotatedDeclsVisitor.cc
   Visitors/CollectDeclNamesVisitor.cc
   Visitors/DeanonymizerVisitor.cc
-)
-
+  Visitors/DeclRefExprAndCallExprDDVisitor
+  Visitors/ForwardDeclDDVisitor.cc
+  Visitors/FunctionDefinitionDDVisitor.cc
+  Visitors/MacroTransformationMapperVisitor.cc
+  )
+  
 target_include_directories(Cpp2C PUBLIC "${PROJECT_SOURCE_DIR}/include")
 
 # Allow undefined symbols in shared objects on Darwin (this is the default

--- a/implementation/src/Callbacks/MacroNameCollector.cc
+++ b/implementation/src/Callbacks/MacroNameCollector.cc
@@ -14,10 +14,12 @@ namespace Callbacks
     MacroNameCollector::MacroNameCollector(
         set<string> &MacroNames,
         set<string> &MultiplyDefinedMacros,
+        bool Verbose,
         SourceManager &SM,
         const LangOptions &LO)
         : MacroNames(MacroNames),
           MultiplyDefinedMacros(MultiplyDefinedMacros),
+          Verbose(Verbose),
           SM(SM),
           LO(LO){};
 
@@ -32,7 +34,9 @@ namespace Callbacks
                 MultiplyDefinedMacros.insert(MacroName);
             }
         }
-        // TODO: Only emit macro definition if verbose
-        emitMacroDefinitionMessage(llvm::errs(), MD, SM, LO);
+        if (Verbose)
+        {
+            emitMacroDefinitionMessage(llvm::errs(), MD, SM, LO);
+        }
     }
 } // namespace Callbacks

--- a/implementation/src/Cpp2C/Cpp2CAction.cc
+++ b/implementation/src/Cpp2C/Cpp2CAction.cc
@@ -8,7 +8,7 @@ namespace Cpp2C
     using namespace std;
     using namespace clang;
 
-    string USAGE_STRING = "USAGE: cpp2c (transform|tr [(-i|--in-place)|(--verbose|-v)|(--standard-header-macros|-shm)*])|(remove_annotations|ra [-i|--in-place]|(deduplicate|dd [-i|--in-place])) FILE_NAME";
+    string USAGE_STRING = "USAGE: cpp2c (transform|tr [(-i|--in-place)|(--verbose|-v)|(--standard-header-macros|-shm)*])|(deduplicate|dd [-i|--in-place])|(remove_annotations|ra [-i|--in-place]) FILE_NAME";
 
     unique_ptr<ASTConsumer>
     Cpp2CAction::CreateASTConsumer(

--- a/implementation/src/Cpp2C/Cpp2CAction.cc
+++ b/implementation/src/Cpp2C/Cpp2CAction.cc
@@ -8,7 +8,7 @@ namespace Cpp2C
     using namespace std;
     using namespace clang;
 
-    string USAGE_STRING = "USAGE: cpp2c (transform|tr [(-i|--in-place)|(--verbose|-v)|(--standard-header-macros|-shm)*])|(remove_annotations|ra [-i|--in-place]) FILE_NAME";
+    string USAGE_STRING = "USAGE: cpp2c (transform|tr [(-i|--in-place)|(--verbose|-v)|(--standard-header-macros|-shm)*])|(remove_annotations|ra [-i|--in-place]|(deduplicate|dd [-i|--in-place])) FILE_NAME";
 
     unique_ptr<ASTConsumer>
     Cpp2CAction::CreateASTConsumer(

--- a/implementation/src/Cpp2C/Cpp2CAction.cc
+++ b/implementation/src/Cpp2C/Cpp2CAction.cc
@@ -1,5 +1,6 @@
 #include "Cpp2C/Cpp2CAction.hh"
 #include "Transformer/TransformerConsumer.hh"
+#include "Deduplicator/DeduplicatorConsumer.hh"
 #include "AnnotationRemover/AnnotationRemoverConsumer.hh"
 
 namespace Cpp2C
@@ -33,6 +34,11 @@ namespace Cpp2C
         {
             auto AR = make_unique<AnnotationRemover::AnnotationRemoverConsumer>(ARSettings);
             return AR;
+        }
+        else if (Command == DEDUPLICATE)
+        {
+            auto DD = make_unique<Deduplicator::DeduplicatorConsumer>(DDSettings);
+            return DD;
         }
         llvm::errs() << "No command passed\n";
         exit(1);
@@ -86,6 +92,25 @@ namespace Cpp2C
             }
         }
 
+        // Dedpuplicate
+        else if (command == "dd" || command == "deduplicate")
+        {
+            Command = DEDUPLICATE;
+            for (auto it = optionalArgs; it != args.end(); ++it)
+            {
+                std::string arg = *it;
+                if (arg == "-i" || arg == "--in-place")
+                {
+                    DDSettings.OverwriteFiles = true;
+                }
+                else
+                {
+                    llvm::errs() << "Unknown annotation remover argument: " << arg << '\n';
+                    exit(1);
+                }
+            }
+        }
+
         // Remove annotations
         else if (command == "ra" || command == "remove_annotations")
         {
@@ -95,7 +120,7 @@ namespace Cpp2C
                 std::string arg = *it;
                 if (arg == "-i" || arg == "--in-place")
                 {
-                    TSettings.OverwriteFiles = true;
+                    ARSettings.OverwriteFiles = true;
                 }
                 else
                 {

--- a/implementation/src/CppSig/MacroForest.cc
+++ b/implementation/src/CppSig/MacroForest.cc
@@ -15,8 +15,14 @@ namespace CppSig
         }
     }
 
-    MacroForest::MacroForest(clang::CompilerInstance &CI, Roots &roots)
-        : CI(CI), MacroRoots(roots), Ctx(CI.getASTContext()){};
+    MacroForest::MacroForest(
+        clang::CompilerInstance &CI,
+        bool Verbose,
+        Roots &roots)
+        : CI(CI),
+          Verbose(Verbose),
+          MacroRoots(roots),
+          Ctx(CI.getASTContext()){};
 
     clang::SourceRange MacroForest::getSpellingRange(
         clang::SourceLocation S,
@@ -89,7 +95,10 @@ namespace CppSig
         }
 
         // TODO: Only emit macro expansions if verbose
-        Utils::Logging::emitMacroExpansionMessage(llvm::errs(), SpellingRange, MD, SM, LO);
+        if (Verbose)
+        {
+            Utils::Logging::emitMacroExpansionMessage(llvm::errs(), SpellingRange, MD, SM, LO);
+        }
 
         // ATTENTION: If we are in a macro-argument expansion, we have to
         // store our expansion stack beforehand as we would pop too much here.

--- a/implementation/src/Deduplicator/DeduplicatorConsumer.cc
+++ b/implementation/src/Deduplicator/DeduplicatorConsumer.cc
@@ -1,0 +1,160 @@
+#include "Deduplicator/DeduplicatorConsumer.hh"
+#include "Visitors/DeclRefExprAndCallExprDDVisitor.hh"
+#include "Visitors/ForwardDeclDDVisitor.hh"
+#include "Visitors/MacroTransformationMapperVisitor.hh"
+#include "Visitors/FunctionDefinitionDDVisitor.hh"
+#include "Utils/ExpansionUtils.hh"
+#include "Utils/TransformedDeclarationAnnotation.hh"
+
+#include "clang/AST/ASTContext.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "clang/Basic/SourceManager.h"
+
+namespace Deduplicator
+{
+
+    DeduplicatorConsumer::DeduplicatorConsumer(DeduplicatorSettings DDSettings)
+        : DDSettings(DDSettings) {}
+
+    void DeduplicatorConsumer::HandleTranslationUnit(clang::ASTContext &Ctx)
+    {
+        auto &SM = Ctx.getSourceManager();
+        auto &LO = Ctx.getLangOpts();
+        auto RW = clang::Rewriter(SM, LO);
+        auto TUD = Ctx.getTranslationUnitDecl();
+
+        // Deduplicate struct/union/enum forward declarations (TagDecls)
+        auto FDV = Visitors::ForwardDeclDDVisitor(RW);
+        FDV.TraverseTranslationUnitDecl(TUD);
+
+        // Map each transformed macro to its transformed declarations
+        auto MTMV = Visitors::MacroTransformationMapperVisitor();
+        MTMV.TraverseTranslationUnitDecl(TUD);
+
+        std::map<std::string, clang::Decl *> MacroHashToCanonDecl;
+        // Map each transformed macro to its "canonical declaration", i.e.
+        // the transformed declaration to keep when deduplicating
+        // Also map each transformed decls to its macro hash
+        for (auto &&it : MTMV.getTransformedMacroMapRef())
+        {
+            auto MacroHash = it.first;
+            auto TransformedDecls = it.second;
+
+            // Find the canonical decl, if one was already chosen in a prior run
+            clang::Decl *CanonD = nullptr;
+            for (auto &&D : TransformedDecls)
+            {
+                if (Utils::getFirstAnnotationOrEmpty(D).find("canonical") != std::string::npos)
+                {
+                    CanonD = D;
+                }
+            }
+            // If we didn't find a canonical decl, then assign the first one in
+            // the vector of transformed decls to be the canonical decl
+            if (CanonD == nullptr)
+            {
+                CanonD = TransformedDecls.front();
+                // FIXME: There has to be a better way to do this
+                // UPDATE: There is!
+                // See here for a great way to refactor this: https://reviews.llvm.org/D31343
+                // Look at AnnotateAttr:Create
+
+                // Get the range the decl originally covered
+                auto ReplacementRange = SM.getExpansionRange(CanonD->getSourceRange());
+
+                // Get the current JSON annotation
+                auto annotation = Utils::getFirstAnnotationOrEmpty(CanonD);
+                auto j = Utils::annotationStringToJson(annotation);
+                // Add the field '"canonical" : true' to it
+                j["canonical"] = true;
+                auto newAnnotationString = Utils::escape_json(j.dump());
+
+                // Replace the decl's annotation with the new one
+                CanonD->dropAttrs();
+                auto Atty = clang::AnnotateAttr::Create(Ctx, newAnnotationString);
+                CanonD->addAttr(Atty);
+
+                // Print the new decl to a string
+                std::string S;
+                llvm::raw_string_ostream SS(S);
+                CanonD->print(SS);
+
+                // Replace the old decl with the new one
+                auto failed = RW.ReplaceText(ReplacementRange, SS.str());
+                if (failed)
+                {
+                    llvm::errs() << "Failed to remove attribute range: ";
+                    ReplacementRange.getAsRange().dump(SM);
+                }
+            }
+            MacroHashToCanonDecl[MacroHash] = CanonD;
+        }
+
+        // Create a set of all the canonical decls
+        // Should all be unique anyway
+        std::set<clang::Decl *> CanonicalDecls;
+        for (auto &&it : MacroHashToCanonDecl)
+        {
+            auto CD = it.second;
+            CanonicalDecls.insert(CD);
+        }
+        // Create a set of all transformed declaration names
+        std::set<std::string> TransformedDeclNames;
+        for (auto &&it : MTMV.getTransformedDeclToMacroHashRef())
+        {
+            auto D = it.first;
+            if (auto ND = clang::dyn_cast_or_null<clang::NamedDecl>(D))
+            {
+                TransformedDeclNames.insert(ND->getNameAsString());
+            }
+        }
+
+        // Visit each function definiton, and remove those which have a
+        // previous declaration without the key "canonical" in their
+        // JSON annotation
+        auto FDDV = Visitors::FunctionDefinitionDDVisitor(RW, TransformedDeclNames, CanonicalDecls);
+        FDDV.TraverseTranslationUnitDecl(TUD);
+
+        // Map each transformed decl name to the name of its transformed
+        // macro's canonical decl (which may just be itself)
+        std::map<std::string, std::string> TransformedDeclNameToCanonicalName;
+        for (auto &&it : MTMV.getTransformedDeclToMacroHashRef())
+        {
+            auto TD = it.first;
+            auto TransformedName = clang::dyn_cast<clang::NamedDecl>(TD)->getNameAsString();
+
+            auto MacroHash = it.second;
+            auto CanonicalD = MacroHashToCanonDecl[MacroHash];
+            auto CanonicalName = clang::dyn_cast<clang::NamedDecl>(CanonicalD)->getNameAsString();
+
+            TransformedDeclNameToCanonicalName[TransformedName] = CanonicalName;
+        }
+
+        // Replace calls/var derefs to deduplicated definitions with their
+        // canonical counterparts
+        auto DRECEDV = Visitors::DeclRefExprAndCallExprDDVisitor(RW, TransformedDeclNameToCanonicalName);
+        DRECEDV.TraverseTranslationUnitDecl(TUD);
+
+        // TODO
+        // Add the number of deduplicated decls to the JSON annotation
+        // of each canonical decl
+
+        // Rewrite changes, or print them to stdout
+        if (DDSettings.OverwriteFiles)
+        {
+            RW.overwriteChangedFiles();
+        }
+        else
+        {
+            // Print the results of the rewriting for the current file
+            if (auto RewriteBuf = RW.getRewriteBufferFor(SM.getMainFileID()))
+            {
+                RewriteBuf->write(llvm::outs());
+            }
+            else
+            {
+                llvm::errs() << "No changes\n";
+            }
+        }
+    }
+} // namespace Deduplicator

--- a/implementation/src/Deduplicator/DeduplicatorConsumer.cc
+++ b/implementation/src/Deduplicator/DeduplicatorConsumer.cc
@@ -47,6 +47,7 @@ namespace Deduplicator
                 if (Utils::getFirstAnnotationOrEmpty(D).find("canonical") != std::string::npos)
                 {
                     CanonD = D;
+                    break;
                 }
             }
             // If we didn't find a canonical decl, then assign the first one in

--- a/implementation/src/Deduplicator/DeduplicatorConsumer.cc
+++ b/implementation/src/Deduplicator/DeduplicatorConsumer.cc
@@ -54,10 +54,6 @@ namespace Deduplicator
             if (CanonD == nullptr)
             {
                 CanonD = TransformedDecls.front();
-                // FIXME: There has to be a better way to do this
-                // UPDATE: There is!
-                // See here for a great way to refactor this: https://reviews.llvm.org/D31343
-                // Look at AnnotateAttr:Create
 
                 // Get the range the decl originally covered
                 auto ReplacementRange = SM.getExpansionRange(CanonD->getSourceRange());

--- a/implementation/src/Deduplicator/DeduplicatorConsumer.cc
+++ b/implementation/src/Deduplicator/DeduplicatorConsumer.cc
@@ -34,7 +34,7 @@ namespace Deduplicator
         std::map<std::string, clang::Decl *> MacroHashToCanonDecl;
         // Map each transformed macro to its "canonical declaration", i.e.
         // the transformed declaration to keep when deduplicating
-        // Also map each transformed decls to its macro hash
+        // Also map each transformed decl to its macro hash
         for (auto &&it : MTMV.getTransformedMacroMapRef())
         {
             auto MacroHash = it.first;

--- a/implementation/src/Transformer/TransformerConsumer.cc
+++ b/implementation/src/Transformer/TransformerConsumer.cc
@@ -47,6 +47,7 @@ namespace Transformer
         MacroNameCollector *MNC = new MacroNameCollector(
             MacroNames,
             MultiplyDefinedMacros,
+            TSettings.Verbose,
             CI->getSourceManager(),
             CI->getLangOpts());
         CppSig::MacroForest *MF = new MacroForest(*CI, ExpansionRoots);

--- a/implementation/src/Transformer/TransformerConsumer.cc
+++ b/implementation/src/Transformer/TransformerConsumer.cc
@@ -50,7 +50,9 @@ namespace Transformer
             TSettings.Verbose,
             CI->getSourceManager(),
             CI->getLangOpts());
-        CppSig::MacroForest *MF = new MacroForest(*CI, ExpansionRoots);
+        CppSig::MacroForest *MF = new MacroForest(*CI,
+                                                  TSettings.Verbose,
+                                                  ExpansionRoots);
         PP.addPPCallbacks(unique_ptr<PPCallbacks>(MNC));
         PP.addPPCallbacks(unique_ptr<PPCallbacks>(MF));
     }

--- a/implementation/src/Transformer/TransformerConsumer.cc
+++ b/implementation/src/Transformer/TransformerConsumer.cc
@@ -289,7 +289,10 @@ namespace Transformer
                     TD->getInvocationReplacementRange(), StringRef(CallOrRef));
                 assert(!rewriteFailed);
                 // TODO: Only emit transformed expansion if verbose
-                emitTransformedExpansionMessage(errs(), TopLevelExpansion, Ctx, SM, LO);
+                if (TSettings.Verbose)
+                {
+                    emitTransformedExpansionMessage(errs(), TopLevelExpansion, Ctx, SM, LO);
+                }
             }
 
             // Emit transformed definition
@@ -307,7 +310,10 @@ namespace Transformer
                     StringRef(FullTransformationDefinition + "\n\n"));
                 assert(!rewriteFailed);
                 // TODO: Only emit transformed definition if verbose
-                emitTransformedDefinitionMessage(errs(), TD, Ctx, SM, LO);
+                if (TSettings.Verbose)
+                {
+                    emitTransformedDefinitionMessage(errs(), TD, Ctx, SM, LO);
+                }
             }
 
             // Free the TransformedDefinition object since it is no longer needed at this point

--- a/implementation/src/Utils/ExpansionUtils.cc
+++ b/implementation/src/Utils/ExpansionUtils.cc
@@ -685,35 +685,4 @@ namespace Utils
         return PointeeType;
     }
 
-    std::string getFirstAnnotationOrEmpty(clang::Decl *D)
-    {
-        for (auto &&it : D->attrs())
-        {
-            if (auto attrName = it->getAttrName())
-            {
-                std::string attrNameStr = attrName->getName().str();
-                if (attrNameStr == "annotate")
-                {
-                    std::string SS;
-                    llvm::raw_string_ostream S(SS);
-                    auto &PP = D->getASTContext().getPrintingPolicy();
-                    it->printPretty(S, PP);
-                    std::string annotation = S.str();
-                    return annotation;
-                }
-            }
-        }
-        return "";
-    }
-
-    nlohmann::json annotationStringToJson(std::string annotation)
-    {
-        // Remove all the parts of the annotation around the JSON string
-        std::size_t JSONBegin = annotation.find_first_of('{');
-        std::size_t JSONEnd = annotation.find_last_of('}');
-        auto JSONLen = JSONEnd - JSONBegin + 1;
-        auto JSONString = annotation.substr(JSONBegin, JSONLen);
-        return nlohmann::json::parse(JSONString);
-    }
-
 } // namespace Utils

--- a/implementation/src/Utils/ExpansionUtils.cc
+++ b/implementation/src/Utils/ExpansionUtils.cc
@@ -685,4 +685,35 @@ namespace Utils
         return PointeeType;
     }
 
+    std::string getFirstAnnotationOrEmpty(clang::Decl *D)
+    {
+        for (auto &&it : D->attrs())
+        {
+            if (auto attrName = it->getAttrName())
+            {
+                std::string attrNameStr = attrName->getName().str();
+                if (attrNameStr == "annotate")
+                {
+                    std::string SS;
+                    llvm::raw_string_ostream S(SS);
+                    auto &PP = D->getASTContext().getPrintingPolicy();
+                    it->printPretty(S, PP);
+                    std::string annotation = S.str();
+                    return annotation;
+                }
+            }
+        }
+        return "";
+    }
+
+    nlohmann::json annotationStringToJson(std::string annotation)
+    {
+        // Remove all the parts of the annotation around the JSON string
+        std::size_t JSONBegin = annotation.find_first_of('{');
+        std::size_t JSONEnd = annotation.find_last_of('}');
+        auto JSONLen = JSONEnd - JSONBegin + 1;
+        auto JSONString = annotation.substr(JSONBegin, JSONLen);
+        return nlohmann::json::parse(JSONString);
+    }
+
 } // namespace Utils

--- a/implementation/src/Utils/TransformedDeclarationAnnotation.cc
+++ b/implementation/src/Utils/TransformedDeclarationAnnotation.cc
@@ -22,8 +22,8 @@ namespace Utils
         j.at("macro name").get_to(TDA.NameOfOriginalMacro);
         j.at("macro type").get_to(TDA.MacroType);
         j.at("macro definition file").get_to(TDA.MacroDefinitionDefinitionFileName);
-        j.at("macro macro definition number").get_to(TDA.MacroDefinitionNumber);
-        j.at("macro transformed signature").get_to(TDA.TransformedSignature);
+        j.at("macro definition number").get_to(TDA.MacroDefinitionNumber);
+        j.at("transformed signature").get_to(TDA.TransformedSignature);
     }
 
     std::string escape_json(const std::string &s)
@@ -53,6 +53,23 @@ namespace Utils
             }
         }
         return o.str();
+    }
+
+    std::string hashTDAOriginalMacro(const TransformedDeclarationAnnotation &TDA)
+    {
+        return TDA.NameOfOriginalMacro + ";" +
+               TDA.MacroType + ";" +
+               TDA.MacroDefinitionDefinitionFileName + ";" +
+               std::to_string(TDA.MacroDefinitionNumber);
+    }
+
+    std::string hashTDA(const TransformedDeclarationAnnotation &TDA)
+    {
+        return TDA.NameOfOriginalMacro + ";" +
+               TDA.MacroType + ";" +
+               TDA.TransformedSignature + ';' +
+               TDA.MacroDefinitionDefinitionFileName + ";" +
+               std::to_string(TDA.MacroDefinitionNumber);
     }
 
 } // namespace Utils

--- a/implementation/src/Utils/TransformedDeclarationAnnotation.cc
+++ b/implementation/src/Utils/TransformedDeclarationAnnotation.cc
@@ -72,4 +72,26 @@ namespace Utils
                std::to_string(TDA.MacroDefinitionNumber);
     }
 
+    std::string getFirstAnnotationOrEmpty(clang::Decl *D)
+    {
+        for (auto &&it : D->attrs())
+        {
+            if (auto Atty = clang::dyn_cast_or_null<clang::AnnotateAttr>(it))
+            {
+                return Atty->getAnnotation().str();
+            }
+        }
+        return "";
+    }
+
+    nlohmann::json annotationStringToJson(std::string annotation)
+    {
+        // Remove all the parts of the annotation around the JSON string
+        std::size_t JSONBegin = annotation.find_first_of('{');
+        std::size_t JSONEnd = annotation.find_last_of('}');
+        auto JSONLen = JSONEnd - JSONBegin + 1;
+        auto JSONString = annotation.substr(JSONBegin, JSONLen);
+        return nlohmann::json::parse(JSONString);
+    }
+
 } // namespace Utils

--- a/implementation/src/Visitors/DeanonymizerVisitor.cc
+++ b/implementation/src/Visitors/DeanonymizerVisitor.cc
@@ -19,13 +19,13 @@ namespace Visitors
         const clang::Type *T = QT.getTypePtr();
         if (T->isStructureType() || T->isUnionType() || T->isEnumeralType())
         {
-            llvm::errs() << "Found an typedef of a struct/union/enum " << TD->getName().str() << "\n";
+            // llvm::errs() << "Found an typedef of a struct/union/enum " << TD->getName().str() << "\n";
             // Is this type an anonymous type?
             const clang::TagDecl *TaD = T->getAsTagDecl();
             if (TaD->getDeclName().isEmpty())
             {
                 auto TDName = TD->getName();
-                llvm::errs() << "typedef'd struct/union/enum " << TDName.str() << " is anonymous\n";
+                // llvm::errs() << "typedef'd struct/union/enum " << TDName.str() << " is anonymous\n";
 
                 // If so, then rewrite it to not be anonymous by
                 // inserting the typedef name just before the definition
@@ -33,16 +33,16 @@ namespace Visitors
                 auto &SM = Ctx.getSourceManager();
                 auto Def = TaD->getDefinition();
 
-                {
-                    if (Def == nullptr)
-                    {
-                        llvm::errs() << "Deanonymizing a typedef'd struct/union/enum without a definition: " << TDName.str() << "\n";
-                    }
-                    else
-                    {
-                        llvm::errs() << "Deanonymizing a typedef'd struct/union/enum with a definition: " << TDName.str() << "\n";
-                    }
-                }
+                // {
+                //     if (Def == nullptr)
+                //     {
+                //         llvm::errs() << "Deanonymizing a typedef'd struct/union/enum without a definition: " << TDName.str() << "\n";
+                //     }
+                //     else
+                //     {
+                //         llvm::errs() << "Deanonymizing a typedef'd struct/union/enum with a definition: " << TDName.str() << "\n";
+                //     }
+                // }
 
                 auto LBraceLoc = Def->getBraceRange().getBegin();
                 LBraceLoc = SM.getExpansionLoc(LBraceLoc);

--- a/implementation/src/Visitors/DeclRefExprAndCallExprDDVisitor.cc
+++ b/implementation/src/Visitors/DeclRefExprAndCallExprDDVisitor.cc
@@ -41,7 +41,7 @@ namespace Visitors
             ReferencedDecl = clang::dyn_cast_or_null<clang::NamedDecl>(PD);
         }
 
-        // Check that wer are replacing a transformed decl
+        // Check that we are replacing a transformed decl
         if (TransformedDeclToCanonicalDecl.find(ReferencedDecl) !=
             TransformedDeclToCanonicalDecl.end())
         {

--- a/implementation/src/Visitors/DeclRefExprAndCallExprDDVisitor.cc
+++ b/implementation/src/Visitors/DeclRefExprAndCallExprDDVisitor.cc
@@ -1,0 +1,52 @@
+#include "Visitors/DeclRefExprAndCallExprDDVisitor.hh"
+
+#include "clang/Basic/SourceManager.h"
+
+namespace Visitors
+{
+    DeclRefExprAndCallExprDDVisitor::DeclRefExprAndCallExprDDVisitor(
+        clang::Rewriter &RW,
+        std::map<std::string, std::string> &TransformedDeclNameToCanonicalName)
+        : RW(RW),
+          TransformedDeclNameToCanonicalName(TransformedDeclNameToCanonicalName) {}
+
+    bool DeclRefExprAndCallExprDDVisitor::VisitExpr(clang::Expr *E)
+    {
+        // Get the name of the referenced deduped decl
+        std::string ReferencedName;
+        if (auto DRE = clang::dyn_cast_or_null<clang::DeclRefExpr>(E))
+        {
+            ReferencedName = DRE->getFoundDecl()->getNameAsString();
+        }
+        else if (auto CE = clang::dyn_cast_or_null<clang::CallExpr>(E))
+        {
+            ReferencedName = CE->getDirectCallee()->getNameAsString();
+        }
+        // Only visit DeclRefExpr and CallExpr
+        else
+        {
+            return true;
+        }
+
+        // Check that wer are replacing a transformed decl name
+        if (TransformedDeclNameToCanonicalName.find(ReferencedName) !=
+            TransformedDeclNameToCanonicalName.end())
+        {
+            // Replace the first n characters of the expression,
+            // where n is the length of the referenced name,
+            // with the name of the canonical decl
+            auto CanonicalName = TransformedDeclNameToCanonicalName[ReferencedName];
+
+            auto &SM = RW.getSourceMgr();
+            auto Begin = SM.getExpansionLoc(E->getBeginLoc());
+            // Important: Need to subtract 1 here for range to be correct
+            auto End = Begin.getLocWithOffset(ReferencedName.length() - 1);
+            auto RewriteRange = clang::SourceRange(Begin, End);
+
+            bool failed = RW.ReplaceText(RewriteRange, CanonicalName);
+            assert(!failed);
+        }
+
+        return true;
+    }
+} // namespace Visitors

--- a/implementation/src/Visitors/ForwardDeclDDVisitor.cc
+++ b/implementation/src/Visitors/ForwardDeclDDVisitor.cc
@@ -1,5 +1,5 @@
 #include "Visitors/ForwardDeclDDVisitor.hh"
-#include "Utils/ExpansionUtils.hh"
+#include "Utils/TransformedDeclarationAnnotation.hh"
 
 #include "clang/Basic/SourceManager.h"
 

--- a/implementation/src/Visitors/ForwardDeclDDVisitor.cc
+++ b/implementation/src/Visitors/ForwardDeclDDVisitor.cc
@@ -1,0 +1,43 @@
+#include "Visitors/ForwardDeclDDVisitor.hh"
+#include "Utils/ExpansionUtils.hh"
+
+#include "clang/Basic/SourceManager.h"
+
+namespace Visitors
+{
+
+    ForwardDeclDDVisitor::ForwardDeclDDVisitor(clang::Rewriter &RW) : RW(RW) {}
+
+    bool ForwardDeclDDVisitor::VisitTagDecl(clang::TagDecl *TD)
+    {
+        // Don't remove definitions
+        if (TD->isThisDeclarationADefinition())
+        {
+            return true;
+        }
+        // Don't remove declarations which have no declarations before them
+        if (TD->getPreviousDecl() == NULL)
+        {
+            return true;
+        }
+
+        // Remove declarations which:
+        // 1)   Are annotated with the tag "CPP2C"
+        // 2)   Have a previous decl
+        std::string s = Utils::getFirstAnnotationOrEmpty(TD);
+        if (s.find("CPP2C") != std::string::npos)
+        {
+            if (TD->getPreviousDecl() != NULL)
+            {
+                auto &SM = RW.getSourceMgr();
+                auto Range = SM.getExpansionRange(TD->getSourceRange());
+                // Increment end loc by 1 to remove semicolon after declaration
+                Range.setEnd(Range.getEnd().getLocWithOffset(1));
+
+                bool failed = RW.RemoveText(Range);
+                assert(!failed);
+            }
+        }
+        return true;
+    }
+} // namespace Visitors

--- a/implementation/src/Visitors/FunctionDefinitionDDVisitor.cc
+++ b/implementation/src/Visitors/FunctionDefinitionDDVisitor.cc
@@ -1,0 +1,58 @@
+#include "Visitors/FunctionDefinitionDDVisitor.hh"
+#include "Utils/ExpansionUtils.hh"
+
+namespace Visitors
+{
+
+    FunctionDefinitionDDVisitor::FunctionDefinitionDDVisitor(
+        clang::Rewriter &RW,
+        std::set<std::string> &TransformedDeclNames,
+        std::set<clang::Decl *> &CanonicalDecls)
+        : RW(RW),
+          TransformedDeclNames(TransformedDeclNames),
+          CanonicalDecls(CanonicalDecls) {}
+
+    bool FunctionDefinitionDDVisitor::VisitNamedDecl(clang::NamedDecl *ND)
+    {
+        // Only visit transformed definitions
+        if (TransformedDeclNames.find(ND->getNameAsString()) ==
+            TransformedDeclNames.end())
+        {
+            return true;
+        }
+
+        // Only visit function definitions and variable initializations
+        if (
+            (!llvm::isa_and_nonnull<clang::FunctionDecl>(ND) ||
+             !clang::dyn_cast_or_null<clang::FunctionDecl>(ND)->isThisDeclarationADefinition()) &&
+            (!llvm::isa_and_nonnull<clang::VarDecl>(ND) ||
+             !clang::dyn_cast_or_null<clang::VarDecl>(ND)->hasInit()))
+        {
+            return true;
+        }
+
+        // Get the previous declaration (should be a single one)
+        if (auto PD = ND->getPreviousDecl())
+        {
+            // Only erase noncanonical decls
+            if (CanonicalDecls.find(PD) == CanonicalDecls.end())
+            {
+                // Not sure if it matters if I use ND, FD, or PD here
+                auto &Ctx = ND->getASTContext();
+                auto &SM = Ctx.getSourceManager();
+                auto PDRange = SM.getExpansionRange(PD->getSourceRange());
+                auto FDRange = SM.getExpansionRange(ND->getSourceRange());
+                // Extend ranges by 1 to account for trailing semicolon
+                PDRange.setEnd(PDRange.getEnd().getLocWithOffset(1));
+                FDRange.setEnd(FDRange.getEnd().getLocWithOffset(1));
+                bool failed;
+                failed = RW.RemoveText(PDRange);
+                assert(!failed);
+                RW.RemoveText(FDRange);
+                assert(!failed);
+            }
+        }
+        return true;
+    }
+
+} // namespace Visitors

--- a/implementation/src/Visitors/MacroTransformationMapperVisitor.cc
+++ b/implementation/src/Visitors/MacroTransformationMapperVisitor.cc
@@ -1,0 +1,69 @@
+#include "Visitors/MacroTransformationMapperVisitor.hh"
+#include "Utils/ExpansionUtils.hh"
+#include "Utils/TransformedDeclarationAnnotation.hh"
+
+#include "nlohmann/single_include/json.hpp"
+
+namespace Visitors
+{
+    bool MacroTransformationMapperVisitor::VisitDecl(clang::Decl *D)
+    {
+        // Only visit transformed decls, not definitions
+        if (auto VD = clang::dyn_cast_or_null<clang::VarDecl>(D))
+        {
+            if (VD->hasInit())
+            {
+                return true;
+            }
+        }
+        else if (auto FD = clang::dyn_cast_or_null<clang::FunctionDecl>(D))
+        {
+            if (FD->isThisDeclarationADefinition())
+            {
+                return true;
+            }
+        }
+
+        // Get this decl's first annotation
+        std::string annotation = Utils::getFirstAnnotationOrEmpty(D);
+        // Check that this annotation is in fact one that was
+        // emitted by Cpp2C
+        if (annotation.find("emitted by CPP2C") != std::string::npos)
+        {
+            try
+            {
+                nlohmann::json j = Utils::annotationStringToJson(annotation);
+
+                // Create the unique macro hash based on data in
+                // the JSON object
+                Utils::TransformedDeclarationAnnotation TDA;
+                Utils::from_json(j, TDA);
+                std::string hash = Utils::hashTDA(TDA);
+
+                // Add it to the list of transformed declarations for
+                // this macro
+                TransformedMacroMap[hash].push_back(D);
+                TransformedDeclToMacroHash[D] = hash;
+            }
+            catch (nlohmann::json::parse_error &e)
+            {
+                llvm::errs() << e.what() << "\n";
+                return true;
+            }
+        }
+        return true;
+    }
+
+    std::map<std::string, std::vector<clang::Decl *>>
+        &MacroTransformationMapperVisitor::getTransformedMacroMapRef()
+    {
+        return TransformedMacroMap;
+    }
+
+    std::map<clang::Decl *, std::string>
+        &MacroTransformationMapperVisitor::getTransformedDeclToMacroHashRef()
+    {
+        return TransformedDeclToMacroHash;
+    }
+
+} // namespace Visitors

--- a/implementation/tests/conditional_evaluation.c
+++ b/implementation/tests/conditional_evaluation.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#define AND(a, b) ((a) ? (b) : 0)
+
+int main(int argc, char const *argv[])
+{
+    int *p = NULL;
+    int r = AND(p, *p);
+    return 0;
+}

--- a/implementation/tests/structs_unions_enums.c
+++ b/implementation/tests/structs_unions_enums.c
@@ -27,6 +27,7 @@ int main(int argc, char const *argv[])
 {
     S s;
     GET_X_STATIC(s);
+    GET_X_STATIC(s);
     GET_X_PTR((&s));
 
     union U u;

--- a/implementation/wrappers/cpp2c.in
+++ b/implementation/wrappers/cpp2c.in
@@ -8,7 +8,7 @@ argv=("$@")
 
 # Usage info string
 # FIXME: This has tight coupling with the variable USAGE_STRING in Cpp2CAction.cc
-USAGE_STRING="USAGE: cpp2c (transform|tr [(-i|--in-place)|(--verbose|-v)|(--standard-header-macros|-shm)*])|(remove_annotations|ra [-i|--in-place]) FILE_NAME"
+USAGE_STRING="USAGE: cpp2c (transform|tr [(-i|--in-place)|(--verbose|-v)|(--standard-header-macros|-shm)*])|(remove_annotations|ra [-i|--in-place]|(deduplicate|dd [-i|--in-place])) FILE_NAME"
 
 # Helper method for printing errors messages
 function exit_with_error() {

--- a/implementation/wrappers/cpp2c.in
+++ b/implementation/wrappers/cpp2c.in
@@ -8,7 +8,7 @@ argv=("$@")
 
 # Usage info string
 # FIXME: This has tight coupling with the variable USAGE_STRING in Cpp2CAction.cc
-USAGE_STRING="USAGE: cpp2c (transform|tr [(-i|--in-place)|(--verbose|-v)|(--standard-header-macros|-shm)*])|(remove_annotations|ra [-i|--in-place]|(deduplicate|dd [-i|--in-place])) FILE_NAME"
+USAGE_STRING="USAGE: cpp2c (transform|tr [(-i|--in-place)|(--verbose|-v)|(--standard-header-macros|-shm)*])|(deduplicate|dd [-i|--in-place])|(remove_annotations|ra [-i|--in-place]) FILE_NAME"
 
 # Helper method for printing errors messages
 function exit_with_error() {

--- a/implementation/wrappers/cpp2c.in
+++ b/implementation/wrappers/cpp2c.in
@@ -43,7 +43,7 @@ for (( j=0; j<argc; j++ )); do
 
     # Check that the user passed a valid command
     if [[ $j = 0 ]]; then
-        if [[ $arg != "tr" && $arg != "transform" && $arg != "ra" && arg != "remove_annotations" ]]; then
+        if [[ $arg != "tr" && $arg != "transform" && $arg != "dd" && $arg != "deduplicate" && $arg != "ra" && arg != "remove_annotations" ]]; then
             exit_with_error "Unkown command '$arg'"
         fi
     fi
@@ -51,6 +51,8 @@ for (( j=0; j<argc; j++ )); do
     # Commands
     if [[ $arg = "tr" || $arg = "transform" ]]; then
         clang_arg "transform"
+    elif [[ $arg = "dd" || $arg = "deduplicate" ]]; then
+        clang_arg "deduplicate"
     elif [[ $arg = "ra" || $arg = "remove_annotations" ]]; then
         clang_arg "remove_annotations"
 


### PR DESCRIPTION
# Deduplicator Command for Cpp2C
## How it Works
1.  Visit each struct/union/enum declaration; i.e., each `TagDecl`.
    - If the current TagDecl is a definition, don't remove it.
      If it has no previous declarations, don't remove it.
      If it is annotated with "CPP2C" and has a previous declaration, then remove it.
2.  Map each unique transformed macro (including polymorphism as a factor in uniqueness) to a vector of its transformed declarations, in the order found by the visitor.
    - We hash each macro to a unique string by combining the macro's name, type, transformed signature, definition file name, and definition number into a single semicolon-delimited string.
3.  Map each unique transformed macro to its "canonical declaration", and "noncanonical declarations".
    - For each transformed macro:
      - If the macro already has a declaration annotated with the key "canonical", then choose that as its canonical definition.
      - Otherwise, choose the first declaration in its vector of transformed declarations to be its canonical declaration.
        The rest of the declarations are its noncanonical declarations.
4.  Visit each function definition / var decl+initialization:
    - If visiting a transformed, noncanonical definition, then remove the definition and its corresponding declaration from the source code.
      - Each definition should have one previous declaration
5.  Visit each function call / var deref.
    - If the call/deref is to a transformed decl, then replace it with a call to its transformed macro's corresponding canonical declaration.
      + This decl could be replaced by itself, which is fine.
6.  For each transformed macro
    - Add to its canonical declaration's JSON annotation the mapping "canonical": true
    - Increment the mapping "deduped definitions" by the number of deduplications for this transformed macro (or just leave as zero if no dedupes occurred).

One implementation detail is that in order for the updates to the decls' JSON annotation strings to work, we first load all the JSON annotations into memory, update them there, and write all the changes to the AST at the end of the deduplication step.